### PR TITLE
pointer sur la version https de contrib

### DIFF
--- a/paquet.xml
+++ b/paquet.xml
@@ -1,12 +1,12 @@
 <paquet
 	prefix="referer_spam"
 	categorie="statistique"
-	version="0.2.6"
+	version="0.2.7"
 	etat="test"
 	compatibilite="[3.0.0;3.2.*]"
 	logo="prive/themes/spip/images/burn-32.png"
 	schema="1.0.0"
-	documentation="http://contrib.spip.net/4751"
+	documentation="https://contrib.spip.net/4751"
 >
 
 	<nom>referer_spam</nom>


### PR DESCRIPTION
Salut Jean-Emmanuel,

il faudrait pointer sur la version https de contrib + créer un nouveau tag.